### PR TITLE
fix: prevent infinite error loop in map component

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -53,3 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Build error - Duplicate props** - Fixed duplicate className prop in Dashboard component Link element
 - **Build error - React hooks** - Fixed useEffect dependency warnings in map component using refs instead of eslint-disable
 - **SEO - Favicon support** - Enhanced favicon configuration with multiple link tags and meta tags for better browser compatibility
+- **Production error - Infinite loop** - Fixed infinite error loop in map component by preventing map recreation on every isDark state change
+- **Production error - SSR safety** - Added window and document guards in map component to prevent client-side exceptions during SSR
+- **Production error - Map initialization** - Changed map creation to run only once on mount instead of recreating on theme changes

--- a/src/app/components/ui/map.tsx
+++ b/src/app/components/ui/map.tsx
@@ -37,9 +37,12 @@ const Map = React.forwardRef<MapRef, MapProps>(
     const initialCenterRef = React.useRef(center)
     const initialZoomRef = React.useRef(zoom)
     const initialThemeRef = React.useRef(theme)
+    const mapCreatedRef = React.useRef(false)
 
     // Detect dark mode
     React.useEffect(() => {
+      if (typeof window === 'undefined') return
+
       if (theme === 'auto') {
         const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
         setIsDark(mediaQuery.matches)
@@ -52,12 +55,16 @@ const Map = React.forwardRef<MapRef, MapProps>(
       }
     }, [theme])
 
+    // Create map only once on mount
     React.useEffect(() => {
-      if (!mapContainer.current) return
+      if (!mapContainer.current || typeof window === 'undefined' || mapCreatedRef.current) return
 
       const getMapStyle = (): maplibregl.StyleSpecification => {
-        // Use current isDark state for initial map creation
-        const isDarkMode = initialThemeRef.current === 'auto' ? isDark : initialThemeRef.current === 'dark'
+        // Use initial theme for map creation
+        const initialIsDark = initialThemeRef.current === 'auto'
+          ? window.matchMedia('(prefers-color-scheme: dark)').matches
+          : initialThemeRef.current === 'dark'
+        const isDarkMode = initialIsDark
 
         if (isDarkMode) {
           return {
@@ -121,23 +128,33 @@ const Map = React.forwardRef<MapRef, MapProps>(
       })
 
       mapInstance.current = map
+      mapCreatedRef.current = true
 
       // Resize map when container size changes (important for mobile)
-      const resizeObserver = new ResizeObserver(() => {
-        if (mapInstance.current) {
-          mapInstance.current.resize()
-        }
-      })
+      let resizeObserver: ResizeObserver | null = null
+      if ('ResizeObserver' in window) {
+        resizeObserver = new ResizeObserver(() => {
+          if (mapInstance.current) {
+            mapInstance.current.resize()
+          }
+        })
 
-      if (mapContainer.current) {
-        resizeObserver.observe(mapContainer.current)
+        if (mapContainer.current) {
+          resizeObserver.observe(mapContainer.current)
+        }
       }
 
       return () => {
-        resizeObserver.disconnect()
-        map.remove()
+        if (resizeObserver) {
+          resizeObserver.disconnect()
+        }
+        if (mapInstance.current) {
+          mapInstance.current.remove()
+          mapInstance.current = null
+        }
+        mapCreatedRef.current = false
       }
-    }, [isDark])
+    }, [])
 
     // Update center and zoom when they change
     React.useEffect(() => {
@@ -262,7 +279,7 @@ export const MapMarker: React.FC<MapMarkerProps> = ({
   const rootRef = React.useRef<any>(null)
 
   React.useEffect(() => {
-    if (!map || !isLoaded) return
+    if (!map || !isLoaded || typeof document === 'undefined') return
 
     let marker: maplibregl.Marker
 


### PR DESCRIPTION
## Overview

Fixes critical production error causing infinite error loop on Vercel deployment. The map component was being recreated on every `isDark` state change, causing the app to crash repeatedly.

## Changes

### Critical Fixes
- **Infinite error loop** - Fixed map component recreating on every `isDark` state change
- **Map initialization** - Changed map creation to run only once on mount (empty dependency array)
- **Multiple instances prevention** - Added `mapCreatedRef` to prevent multiple map instances from being created
- **SSR safety** - Added `typeof window !== 'undefined'` and `typeof document === 'undefined'` guards throughout map component
- **ResizeObserver safety** - Added check for ResizeObserver availability before creating instance

### Technical Details
- Map is now created once on component mount
- Style updates happen separately when theme changes (existing useEffect handles this)
- All browser API access is properly guarded for SSR safety
- Prevents the infinite recreation cycle that was causing Vercel deployment to fail

## Testing
- [x] Build completes successfully
- [x] No infinite error loops
- [x] Map renders correctly on initial load
- [x] Map style updates when theme changes without recreation
- [x] SSR-safe with proper guards

## Impact
This fix resolves the production deployment issue where the app was showing infinite error messages on Vercel.
